### PR TITLE
Fetch MAM History

### DIFF
--- a/libdino/src/service/muc_manager.vala
+++ b/libdino/src/service/muc_manager.vala
@@ -106,8 +106,8 @@ public class MucManager : StreamInteractionModule, Object {
             if (can_do_mam) {
                 var history_sync = stream_interactor.get_module(MessageProcessor.IDENTITY).history_sync;
                 if (conversation == null) {
-                    // We never joined the conversation before, just fetch the latest MAM page
-                    yield history_sync.fetch_latest_page(account, jid.bare_jid, null, new DateTime.from_unix_utc(0), cancellable);
+                    // We never joined the conversation before, fetch latest MAM pages
+                    yield history_sync.fetch_data(account, jid.bare_jid, new DateTime.now(), 10);
                 } else {
                     // Fetch everything up to the last time the user actively joined
                     if (!mucs_sync_cancellables.has_key(account)) {

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -203,6 +203,7 @@ SOURCES
 
     src/ui/contact_details/settings_provider.vala
     src/ui/contact_details/permissions_provider.vala
+    src/ui/contact_details/history_provider.vala
 
     src/ui/conversation_details.vala
 

--- a/main/meson.build
+++ b/main/meson.build
@@ -39,6 +39,7 @@ sources = files(
     'src/ui/chat_input/view.vala',
     'src/ui/contact_details/permissions_provider.vala',
     'src/ui/contact_details/settings_provider.vala',
+    'src/ui/contact_details/history_provider.vala',
     'src/ui/conversation_content_view/call_widget.vala',
     'src/ui/conversation_content_view/chat_state_populator.vala',
     'src/ui/conversation_content_view/content_populator.vala',

--- a/main/src/ui/contact_details/history_provider.vala
+++ b/main/src/ui/contact_details/history_provider.vala
@@ -1,0 +1,52 @@
+using Gee;
+using Gtk;
+
+using Dino.Entities;
+
+using Xmpp;
+
+namespace Dino.Ui.ContactDetails {
+
+public class HistoryProvider : Plugins.ContactDetailsProvider, Object {
+    public string id { get { return "history_settings"; } }
+
+    private StreamInteractor stream_interactor;
+
+    private HashMap<Account, HashMap<Jid, Cancellable>> sync_cancellables = new HashMap<Account, HashMap<Jid, Cancellable>>(Account.hash_func, Account.equals_func);
+
+    public HistoryProvider(StreamInteractor stream_interactor) {
+        this.stream_interactor = stream_interactor;
+    }
+
+    public void populate(Conversation conversation, Plugins.ContactDetails contact_details, Plugins.WidgetType type) {
+        if (type != Plugins.WidgetType.GTK4) return;
+
+        EntityInfo entity_info = stream_interactor.get_module(EntityInfo.IDENTITY);
+
+        string RESYNC_LABEL = _("Resync");
+        string RESYNC_DESC_LABEL = _("Fetch a complete MAM history for this chat");
+        entity_info.has_feature.begin(conversation.account, conversation.counterpart, Xmpp.MessageArchiveManagement.NS_URI, (_, res) => {
+            bool can_do_mam = entity_info.has_feature.end(res);
+            if (can_do_mam) {
+                Button resync_button = new Button.with_label(RESYNC_LABEL);
+                contact_details.add("Permissions", RESYNC_DESC_LABEL, "", resync_button);
+                resync_button.clicked.connect(() => {
+                    if (!sync_cancellables.has_key(conversation.account)) {
+                        sync_cancellables[conversation.account] = new HashMap<Jid, Cancellable>();
+                    }
+
+                    if (!sync_cancellables[conversation.account].has_key(conversation.counterpart.bare_jid)) {
+                        sync_cancellables[conversation.account][conversation.counterpart.bare_jid] = new Cancellable();
+                        var history_sync = stream_interactor.get_module(MessageProcessor.IDENTITY).history_sync;
+                        history_sync.fetch_history.begin(conversation.account, conversation.counterpart.bare_jid, sync_cancellables[conversation.account][conversation.counterpart.bare_jid], (_, res) => {
+                            history_sync.fetch_everything.end(res);
+                            sync_cancellables[conversation.account].unset(conversation.counterpart.bare_jid);
+                        });
+                    }
+                });
+            }
+        });
+    }
+}
+
+}

--- a/main/src/ui/conversation_content_view/content_populator.vala
+++ b/main/src/ui/conversation_content_view/content_populator.vala
@@ -41,9 +41,9 @@ public class ContentProvider : ContentItemCollection, Object {
         return ret;
     }
 
-    public Gee.List<ContentMetaItem> populate_before(Conversation conversation, ContentItem before_item, int n) {
+    public Gee.List<ContentMetaItem> populate_before(Conversation conversation, ContentItem before_item, int n, bool request_from_server = true) {
         Gee.List<ContentMetaItem> ret = new ArrayList<ContentMetaItem>();
-        Gee.List<ContentItem> items = stream_interactor.get_module(ContentItemStore.IDENTITY).get_before(conversation, before_item, n);
+        Gee.List<ContentItem> items = stream_interactor.get_module(ContentItemStore.IDENTITY).get_before(conversation, before_item, n, request_from_server);
         foreach (ContentItem item in items) {
             ret.add(create_content_meta_item(item));
         }

--- a/main/src/ui/conversation_details.vala
+++ b/main/src/ui/conversation_details.vala
@@ -152,6 +152,7 @@ namespace Dino.Ui.ConversationDetails {
         Application app = GLib.Application.get_default() as Application;
         app.plugin_registry.register_contact_details_entry(new ContactDetails.SettingsProvider(stream_interactor));
         app.plugin_registry.register_contact_details_entry(new ContactDetails.PermissionsProvider(stream_interactor));
+        app.plugin_registry.register_contact_details_entry(new ContactDetails.HistoryProvider(stream_interactor));
 
         foreach (Plugins.ContactDetailsProvider provider in app.plugin_registry.contact_details_entries) {
             provider.populate(conversation, contact_details, Plugins.WidgetType.GTK4);


### PR DESCRIPTION
This PR adds the following:

- Button to fetch complete MAM history for conversation (can be found in the details tab)
- (**Experimenta**l) Ability to dynamically fetch MAM pages when scrolling. Scrolling to the latest available message will create an async request to the server to get more messages.