### PR TITLE
Fetch MAM pages when scrolling in chats

### DIFF
--- a/libdino/src/entity/conversation.vala
+++ b/libdino/src/entity/conversation.vala
@@ -2,6 +2,8 @@ using Xmpp;
 
 namespace Dino.Entities {
 
+const int HISTORY_SYNC_MAM_PAGES = 10;
+
 public class Conversation : Object {
 
     public signal void object_updated(Conversation conversation);
@@ -14,6 +16,10 @@ public class Conversation : Object {
         public bool is_muc_semantic() {
             return this == GROUPCHAT || this == GROUPCHAT_PM;
         }
+    }
+
+    public int syncSpeed() {
+        return HISTORY_SYNC_MAM_PAGES;
     }
 
     public int id { get; set; }

--- a/libdino/src/service/content_item_store.vala
+++ b/libdino/src/service/content_item_store.vala
@@ -6,8 +6,6 @@ using Xmpp;
 
 namespace Dino {
 
-const int HISTORY_SYNC_MAM_PAGES = 10;
-
 public class ContentItemStore : StreamInteractionModule, Object {
     public static ModuleIdentity<ContentItemStore> IDENTITY = new ModuleIdentity<ContentItemStore>("content_item_store");
     public string id { get { return IDENTITY.id; } }
@@ -260,8 +258,8 @@ public class ContentItemStore : StreamInteractionModule, Object {
         if (items.size == 0 && request_from_server) {
             // Async request to get earlier messages from the server
             var history_sync = stream_interactor.get_module(MessageProcessor.IDENTITY).history_sync;
-            history_sync.fetch_data.begin(conversation.account, conversation.counterpart.bare_jid, item.time, HISTORY_SYNC_MAM_PAGES, (_, res) => {
-                history_sync.fetch_data.end(res);
+            history_sync.fetch_conversation_data.begin(conversation, item.time, (_, res) => {
+                history_sync.fetch_conversation_data.end(res);
                 debug("History loaded");
                 history_loaded(conversation, item, count);
             });

--- a/libdino/src/service/muc_manager.vala
+++ b/libdino/src/service/muc_manager.vala
@@ -107,7 +107,7 @@ public class MucManager : StreamInteractionModule, Object {
                 var history_sync = stream_interactor.get_module(MessageProcessor.IDENTITY).history_sync;
                 if (conversation == null) {
                     // We never joined the conversation before, fetch latest MAM pages
-                    yield history_sync.fetch_data(account, jid.bare_jid, new DateTime.now(), 10);
+                    yield history_sync.fetch_data(account, jid.bare_jid, new DateTime.now());
                 } else {
                     // Fetch everything up to the last time the user actively joined
                     if (!mucs_sync_cancellables.has_key(account)) {


### PR DESCRIPTION
This PR adds the following:

- (**Experimental**) Ability to dynamically fetch MAM pages when scrolling in chats. Scrolling to the latest available message will create an async request to the server to get more messages.

