### PR TITLE
flatpak builder script revised

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,6 @@ gschemas.compiled
 windows-installer/win64-dist/
 *.exe
 *.dll
+*.flatpak
+linux-distributives
 .flatpak-builder

--- a/build-flatpack.sh
+++ b/build-flatpack.sh
@@ -1,25 +1,85 @@
 #!/bin/bash
 set -e
 
-getFlatpackDependencies(){
+APP_NAME="im.dino.Dino"
+DIST_NAME=${DIST_NAME:-"${APP_NAME}.flatpak"}
+DIST_DIR="$PWD/linux-distributives"
+BUILD_TEMP_DIR="$DIST_DIR/buildtemp"
+BUILD_EXPORT_DIR="$DIST_DIR/export"
+
+msg()
+{
+    echo -e "\e[32m$1\e[0m"
+}
+
+fatal()
+{
+    echo -e "\e[31m$1\e[0m"
+    exit 1
+}
+
+getFlatpakDependencies(){
+    msg "Installing Flatpak dependencies..."
     flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
     flatpak install flathub org.gnome.Sdk//44
     flatpak install flathub org.gnome.Platform//44
+    msg "Flatpak dependencies installed"
 }
 
-prepareModules(){
+pullSharedModules() {
+    msg "Pulling shared modules..."
     git submodule init
     git submodule update
+    msg "Shared modules successfully pulled"
+}
+
+prepare(){
+    getFlatpakDependencies
+    pullSharedModules
 }
 
 build(){
-    FP_TEMP_BUILD_DIR=$(mktemp -d)
-    FP_OUTDIR="builds"
-    flatpak-builder ${FP_TEMP_BUILD_DIR} im.dino.Dino.json
-    flatpak build-export $FP_OUTDIR $FP_TEMP_BUILD_DIR
-    flatpak build-bundle $FP_OUTDIR dino.flatpak
+    msg "Build commencing!"
+    rm -rf $BUILD_TEMP_DIR
+    flatpak-builder $BUILD_TEMP_DIR "${APP_NAME}.json"
+    flatpak build-export $BUILD_EXPORT_DIR $BUILD_TEMP_DIR
+    flatpak build-bundle $BUILD_EXPORT_DIR $DIST_NAME $APP_NAME
+    msg "Flatpack bundle ready and saved to ${DIST_NAME}"
 }
 
-getFlatpackDependencies
-prepareModules
-build
+clean(){
+    msg "Wiping intermediate files..."
+    rm -rf $BUILD_TEMP_DIR $BUILD_EXPORT_DIR
+    msg "Cleanup complete!"
+}
+
+help()
+{
+cat << EOF
+usage: $0 [OPTION]
+  --prepare                  install build dependencies
+  --build                    build the project
+  --clean                    remove build artifacts
+  --help                     show this help
+
+Bundle is saved to ${APP_NAME}.flatpak by default. 
+Set DIST_NAME variable to customize output file name:
+'DIST_NAME=customname.flatpak $0'
+
+Running without parameters is equivalent to running:
+'--prepare', '--build' and '--clean'
+EOF
+}
+
+case $1 in
+    "--prepare" ) prepare ;;
+    "--build" ) build ;;
+    "--help" ) help ;;
+    "--clean" ) clean;;
+    "" )
+        prepare
+        build
+        clean
+        ;;
+    *) fatal "Unknown argument!"
+esac


### PR DESCRIPTION
doesn't use /tmp destinations now, has a --help command and an option to customize bundle name