### PR TITLE
Wait for messages instead of MAM pages when scrolling

### DIFF
--- a/libdino/src/entity/conversation.vala
+++ b/libdino/src/entity/conversation.vala
@@ -2,7 +2,7 @@ using Xmpp;
 
 namespace Dino.Entities {
 
-const int HISTORY_SYNC_MAM_PAGES = 10;
+const int HISTORY_SYNC_MAM_MESSAGES = 20;
 
 public class Conversation : Object {
 
@@ -16,10 +16,6 @@ public class Conversation : Object {
         public bool is_muc_semantic() {
             return this == GROUPCHAT || this == GROUPCHAT_PM;
         }
-    }
-
-    public int syncSpeed() {
-        return HISTORY_SYNC_MAM_PAGES;
     }
 
     public int id { get; set; }

--- a/libdino/src/service/message_processor.vala
+++ b/libdino/src/service/message_processor.vala
@@ -130,17 +130,17 @@ public class MessageProcessor : StreamInteractionModule, Object {
         run_pipeline_announce.begin(account, message_stanza);
     }
 
-    public async void run_pipeline_announce(Account account, Xmpp.MessageStanza message_stanza) {
+    public async bool run_pipeline_announce(Account account, Xmpp.MessageStanza message_stanza) {
         Entities.Message message = yield parse_message_stanza(account, message_stanza);
 
         Conversation? conversation = stream_interactor.get_module(ConversationManager.IDENTITY).get_conversation_for_message(message);
         if (conversation == null) {
-            return;
+            return false;
         }
 
         bool abort = yield received_pipeline.run(message, message_stanza, conversation);
         if (abort) {
-            return;
+            return false;
         }
 
         if (message.direction == Entities.Message.DIRECTION_RECEIVED) {
@@ -150,6 +150,7 @@ public class MessageProcessor : StreamInteractionModule, Object {
         }
 
         message_sent_or_received(message, conversation);
+        return true;
     }
 
     public async Entities.Message parse_message_stanza(Account account, Xmpp.MessageStanza message) {


### PR DESCRIPTION
This should (hopefully) resolve rare issue when server always returns empty pages.