### PR TITLE
Add send button / Enter key settings

### DIFF
--- a/libdino/src/entity/settings.vala
+++ b/libdino/src/entity/settings.vala
@@ -13,6 +13,8 @@ public class Settings : Object {
         convert_utf8_smileys_ = col_to_bool_or_default("convert_utf8_smileys", true);
         check_spelling = col_to_bool_or_default("check_spelling", true);
         default_encryption = col_to_encryption_or_default("default_encryption", Encryption.UNKNOWN);
+        send_button = col_to_bool_or_default("send_button", false);
+        enter_newline = col_to_bool_or_default("enter_newline", false);
     }
 
     private bool col_to_bool_or_default(string key, bool def) {
@@ -100,6 +102,32 @@ public class Settings : Object {
         }
     }
 
+
+    public signal void send_button_update(bool visible);
+    private bool send_button_;
+    public bool send_button {
+        get { return send_button_; }
+        set {
+            db.settings.upsert()
+                .value(db.settings.key, "send_button", true)
+                .value(db.settings.value, value.to_string())
+                .perform();
+            send_button_ = value;
+            send_button_update(value);
+        }
+    }
+
+    private bool enter_newline_;
+    public bool enter_newline {
+        get { return enter_newline_; }
+        set {
+            db.settings.upsert()
+                .value(db.settings.key, "enter_newline", true)
+                .value(db.settings.value, value.to_string())
+                .perform();
+            enter_newline_ = value;
+        }
+    }
 }
 
 }

--- a/main/data/chat_input.ui
+++ b/main/data/chat_input.ui
@@ -17,7 +17,7 @@
                             <object class="GtkButton" id="file_button">
                                 <property name="icon-name">mail-attachment-symbolic</property>
                                 <property name="margin-top">2</property>
-                                <property name="valign">start</property>
+                                <property name="valign">center</property>
                                 <style>
                                     <class name="flat"/>
                                     <class name="dino-chatinput-button"/>
@@ -54,7 +54,7 @@
                                 <property name="icon-name">emoji-people-symbolic</property>
                                 <property name="has-frame">False</property>
                                 <property name="margin-top">2</property>
-                                <property name="valign">start</property>
+                                <property name="valign">center</property>
                                 <style>
                                     <class name="flat"/>
                                     <class name="dino-chatinput-button"/>
@@ -67,7 +67,21 @@
                                 <property name="icon-name">changes-allow-symbolic</property>
                                 <property name="has-frame">False</property>
                                 <property name="margin-top">2</property>
-                                <property name="valign">start</property>
+                                <property name="valign">center</property>
+                                <style>
+                                    <class name="flat"/>
+                                    <class name="dino-chatinput-button"/>
+                                    <class name="image-button"/>
+                                </style>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="GtkButton" id="send_button">
+                                <property name="icon-name">mail-send-symbolic</property>
+                                <property name="has-frame">False</property>
+                                <property name="margin-top">2</property>
+                                <property name="valign">center</property>
+                                <property name="sensitive">false</property>
                                 <style>
                                     <class name="flat"/>
                                     <class name="dino-chatinput-button"/>

--- a/main/data/settings_dialog.ui
+++ b/main/data/settings_dialog.ui
@@ -111,6 +111,35 @@
                         </child>
                     </object>
                 </child>
+                <child>
+                    <object class="AdwPreferencesGroup">
+                        <child>
+                            <object class="AdwActionRow">
+                                <property name="title" translatable="yes">_Display send button</property>
+                                <property name="use-underline">True</property>
+                                <property name="activatable-widget">send_button_switch</property>
+                                <child type="suffix">
+                                    <object class="GtkSwitch" id="send_button_switch">
+                                        <property name="valign">center</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="AdwActionRow">
+                                <property name="title" translatable="yes">_Use Enter key to start a new line</property>
+                                <property name="subtitle" translatable="yes">If disabled, use Shift+Enter to start a new line</property>
+                                <property name="use-underline">True</property>
+                                <property name="activatable-widget">enter_newline_switch</property>
+                                <child type="suffix">
+                                    <object class="GtkSwitch" id="enter_newline_switch">
+                                        <property name="valign">center</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+                    </object>
+                </child>
             </object>
         </child>
     </template>

--- a/main/src/ui/chat_input/chat_text_view.vala
+++ b/main/src/ui/chat_input/chat_text_view.vala
@@ -101,7 +101,10 @@ public class ChatTextView : Box {
                 return true;
             }
 
-            if ((state & ModifierType.SHIFT_MASK) > 0) {
+            Dino.Entities.Settings settings = Dino.Application.get_default().settings;
+
+            if ((state & ModifierType.SHIFT_MASK) > 0
+                || settings.enter_newline) {
                 text_view.buffer.insert_at_cursor("\n", 1);
             } else if (text_view.buffer.text.strip() != "") {
                 send_text();

--- a/main/src/ui/chat_input/view.vala
+++ b/main/src/ui/chat_input/view.vala
@@ -27,6 +27,7 @@ public class View : Box {
     [GtkChild] public unowned MenuButton encryption_button;
     [GtkChild] public unowned Separator file_separator;
     [GtkChild] public unowned Label chat_input_status;
+    [GtkChild] public unowned Button send_button;
 
     public EncryptionButton encryption_widget;
 
@@ -46,6 +47,27 @@ public class View : Box {
         file_button.tooltip_text = Util.string_if_tooltips_active(_("Send a file"));
 
         Util.force_css(frame, "* { border-radius: 3px; }");
+
+        Dino.Entities.Settings settings = Dino.Application.get_default().settings;
+
+        chat_text_view.text_view.buffer.changed.connect(() => {
+            if (chat_text_view.text_view.buffer.text != "") {
+                send_button.sensitive = true;
+            }
+            else {
+                send_button.sensitive = false;
+            }
+        });
+
+        send_button.visible = settings.send_button;
+
+        settings.send_button_update.connect((visible) => {
+            send_button.visible = visible;
+        });
+
+        send_button.clicked.connect(() => {
+            chat_text_view.send_text();
+        });
 
         return this;
     }

--- a/main/src/ui/settings_dialog.vala
+++ b/main/src/ui/settings_dialog.vala
@@ -13,6 +13,8 @@ class SettingsDialog : Adw.PreferencesWindow {
     [GtkChild] private unowned CheckButton encryption_radio_undecided;
     [GtkChild] private unowned CheckButton encryption_radio_omemo;
     [GtkChild] private unowned CheckButton encryption_radio_openpgp;
+    [GtkChild] private unowned Switch send_button_switch;
+    [GtkChild] private unowned Switch enter_newline_switch;
 
     Dino.Entities.Settings settings = Dino.Application.get_default().settings;
 
@@ -27,6 +29,9 @@ class SettingsDialog : Adw.PreferencesWindow {
         encryption_radio_omemo.active = settings.default_encryption == Encryption.OMEMO;
         encryption_radio_openpgp.active = settings.default_encryption == Encryption.PGP;
 
+        send_button_switch.active = settings.send_button;
+        enter_newline_switch.active = settings.enter_newline;
+        enter_newline_switch.sensitive = settings.send_button;
 
         typing_switch.notify["active"].connect(() => { settings.send_typing = typing_switch.active; } );
         marker_switch.notify["active"].connect(() => { settings.send_marker = marker_switch.active; } );
@@ -51,6 +56,15 @@ class SettingsDialog : Adw.PreferencesWindow {
             }
         });
 
+        send_button_switch.notify["active"].connect(() => { settings.send_button = send_button_switch.active; });
+        enter_newline_switch.notify["active"].connect(() => { settings.enter_newline = enter_newline_switch.active; });
+        settings.send_button_update.connect((visible) => {
+            enter_newline_switch.sensitive = visible;
+
+            if (visible == false) {
+                enter_newline_switch.active = visible;
+            }
+        });
     }
 }
 


### PR DESCRIPTION
Two new switches have been added to the application preferences:

- Enable send button
- Use Enter to insert newline ('\n')

The latter cannot be active or sensitive if the former is not active. Otherwise, users would not be able to send messages.

Thanks to horazont for suggesting a separate switch for the behaviour of the Enter key.