### PR TITLE
Offline members

### DIFF
--- a/libdino/src/service/muc_manager.vala
+++ b/libdino/src/service/muc_manager.vala
@@ -262,12 +262,14 @@ public class MucManager : StreamInteractionModule, Object {
     public Gee.List<Jid>? get_occupants(Jid jid, Account account) {
         if (is_groupchat(jid, account)) {
             Gee.List<Jid> ret = new ArrayList<Jid>(Jid.equals_func);
-            Gee.List<Jid>? full_jids = stream_interactor.get_module(PresenceManager.IDENTITY).get_full_jids(jid, account);
-            if (full_jids != null) {
-                ret.add_all(full_jids);
+//            Gee.List<Jid>? full_jids = stream_interactor.get_module(PresenceManager.IDENTITY).get_full_jids(jid, account);
+            Gee.List<Jid>? off_jids = get_offline_members(jid, account);
+//            if (full_jids != null) {
+//                ret.add_all(full_jids);
+                ret.add_all(off_jids);
                 // Remove eventual presence from bare jid
-                ret.remove(jid);
-            }
+                //ret.remove(jid);
+//            }
             return ret;
         }
         return null;

--- a/libdino/src/service/muc_manager.vala
+++ b/libdino/src/service/muc_manager.vala
@@ -262,14 +262,12 @@ public class MucManager : StreamInteractionModule, Object {
     public Gee.List<Jid>? get_occupants(Jid jid, Account account) {
         if (is_groupchat(jid, account)) {
             Gee.List<Jid> ret = new ArrayList<Jid>(Jid.equals_func);
-//            Gee.List<Jid>? full_jids = stream_interactor.get_module(PresenceManager.IDENTITY).get_full_jids(jid, account);
-            Gee.List<Jid>? off_jids = get_offline_members(jid, account);
-//            if (full_jids != null) {
-//                ret.add_all(full_jids);
-                ret.add_all(off_jids);
+            Gee.List<Jid>? full_jids = get_offline_members(jid, account);
+            if (full_jids != null) {
+                ret.add_all(full_jids);
                 // Remove eventual presence from bare jid
-                //ret.remove(jid);
-//            }
+                ret.remove(jid);
+            }
             return ret;
         }
         return null;


### PR DESCRIPTION
Show all members of chat
    
This PR is supposed to change the showing of members of chat.
Beforehead only online members was show in chat members. Now it's all
members who are shown, including the ones who is offline and the one who
didn't accept the invite