### PR TITLE
(Experimental): Display online/offline status for conversation members

### DIFF
--- a/libdino/src/service/call_state.vala
+++ b/libdino/src/service/call_state.vala
@@ -60,7 +60,7 @@ public class Dino.CallState : Object {
         XmppStream stream = stream_interactor.get_stream(call.account);
         if (stream == null) return;
 
-        Gee.List<Jid> occupants = stream_interactor.get_module(MucManager.IDENTITY).get_other_occupants(muc, call.account);
+        Gee.List<Jid> occupants = stream_interactor.get_module(MucManager.IDENTITY).get_other_members(muc, call.account);
         foreach (Jid occupant in occupants) {
             Jid? real_jid = stream_interactor.get_module(MucManager.IDENTITY).get_real_jid(occupant, call.account);
             if (real_jid == null) continue;

--- a/libdino/src/service/muc_manager.vala
+++ b/libdino/src/service/muc_manager.vala
@@ -259,27 +259,46 @@ public class MucManager : StreamInteractionModule, Object {
         return is_groupchat(jid, account) && !is_private_room(account, jid);
     }
 
-    public Gee.List<Jid>? get_occupants(Jid jid, Account account) {
+    public Gee.List<Jid>? get_all_members(Jid jid, Account account) {
         if (is_groupchat(jid, account)) {
             Gee.List<Jid> ret = new ArrayList<Jid>(Jid.equals_func);
-            Gee.List<Jid>? full_jids = get_offline_members(jid, account);
+
+            // This should return all members of the chat
+            Gee.List<Jid>? members = get_offline_members(jid, account);
+            if (members != null) {
+                ret.add_all(members);
+            }
+
+            return ret;
+        }
+
+        return null;
+    }
+
+    public Gee.List<Jid>? get_members(Jid jid, Account account) {
+        if (is_groupchat(jid, account)) {
+            Gee.List<Jid> ret = new ArrayList<Jid>(Jid.equals_func);
+            Gee.List<Jid>? full_jids = stream_interactor.get_module(PresenceManager.IDENTITY).get_full_jids(jid, account);
             if (full_jids != null) {
                 ret.add_all(full_jids);
                 // Remove eventual presence from bare jid
                 ret.remove(jid);
             }
+
             return ret;
         }
+
         return null;
     }
 
-    public Gee.List<Jid>? get_other_occupants(Jid jid, Account account) {
-        Gee.List<Jid>? occupants = get_occupants(jid, account);
+    public Gee.List<Jid>? get_other_members(Jid jid, Account account) {
+        Gee.List<Jid>? members = get_members(jid, account);
         Jid? own_jid = get_own_jid(jid, account);
-        if (occupants != null && own_jid != null) {
-            occupants.remove(own_jid);
+        if (members != null && own_jid != null) {
+            members.remove(own_jid);
         }
-        return occupants;
+
+        return members;
     }
 
     public bool is_groupchat(Jid jid, Account account) {

--- a/main/data/occupant_list_item.ui
+++ b/main/data/occupant_list_item.ui
@@ -6,7 +6,7 @@
         <property name="margin-start">7</property>
         <property name="margin-bottom">3</property>
         <property name="margin-end">7</property>
-        <property name="column-spacing">10</property>
+        <property name="column-spacing">5</property>
         <child>
             <object class="DinoUiAvatarPicture" id="picture">
                 <property name="height-request">30</property>
@@ -21,6 +21,18 @@
                 <property name="xalign">0</property>
                 <layout>
                     <property name="column">1</property>
+                    <property name="row">0</property>
+                </layout>
+            </object>
+        </child>
+        <child>
+            <object class="GtkLabel" id="status_label">
+                <property name="max_width_chars">1</property>
+                <property name="ellipsize">end</property>
+                <property name="hexpand">1</property>
+                <property name="xalign">0</property>
+                <layout>
+                    <property name="column">2</property>
                     <property name="row">0</property>
                 </layout>
             </object>

--- a/main/src/ui/chat_input/occupants_tab_completer.vala
+++ b/main/src/ui/chat_input/occupants_tab_completer.vala
@@ -107,7 +107,7 @@ public class OccupantsTabCompletor {
         Gee.List<string> ret = generate_completions_from_messages(prefix);
 
         // Then, suggest other nicks in alphabetical order
-        Gee.List<Jid>? occupants = stream_interactor.get_module(MucManager.IDENTITY).get_other_occupants(conversation.counterpart, conversation.account);
+        Gee.List<Jid>? occupants = stream_interactor.get_module(MucManager.IDENTITY).get_other_members(conversation.counterpart, conversation.account);
         Gee.List<string> filtered_occupants = new ArrayList<string>();
         if (occupants != null) {
             foreach (Jid jid in occupants) {

--- a/main/src/ui/occupant_menu/list_row.vala
+++ b/main/src/ui/occupant_menu/list_row.vala
@@ -11,6 +11,9 @@ public class ListRow : Object {
     private AvatarPicture picture;
     public Label name_label;
 
+    // TODO: use something more visual for status
+    public Label status;
+
     public Conversation? conversation;
     public Jid? jid;
 
@@ -19,6 +22,8 @@ public class ListRow : Object {
         main_grid = (Grid) builder.get_object("main_grid");
         picture = (AvatarPicture) builder.get_object("picture");
         name_label = (Label) builder.get_object("name_label");
+        status = (Label) builder.get_object("status_label");
+        status.label = "(unknown)";
     }
 
     public ListRow(StreamInteractor stream_interactor, Conversation conversation, Jid jid) {
@@ -36,6 +41,14 @@ public class ListRow : Object {
 
     public Widget get_widget() {
         return main_grid;
+    }
+
+    public void set_online() {
+        status.label = ("");
+    }
+
+    public void set_offline() {
+        status.label = ("(offline)");
     }
 }
 

--- a/plugins/omemo/src/ui/bad_messages_populator.vala
+++ b/plugins/omemo/src/ui/bad_messages_populator.vala
@@ -154,7 +154,7 @@ public class BadMessagesWidget : Box {
         } else if (conversation.type_ == Conversation.Type.GROUPCHAT) {
             who = jid.to_string();
             // `jid` is a real JID. In MUCs, try to show nicks instead (given that the JID is currently online)
-            var occupants = plugin.app.stream_interactor.get_module(MucManager.IDENTITY).get_occupants(conversation.counterpart, conversation.account);
+            var occupants = plugin.app.stream_interactor.get_module(MucManager.IDENTITY).get_members(conversation.counterpart, conversation.account);
             if (occupants == null) return;
             foreach (Jid occupant in occupants) {
                 if (jid.equals_bare(plugin.app.stream_interactor.get_module(MucManager.IDENTITY).get_real_jid(occupant, conversation.account))) {

--- a/plugins/openpgp/src/encryption_list_entry.vala
+++ b/plugins/openpgp/src/encryption_list_entry.vala
@@ -53,7 +53,7 @@ private class EncryptionListEntry : Plugins.EncryptionListEntry, Object {
             }
         } else if (conversation.type_ == Conversation.Type.GROUPCHAT) {
             Gee.List<Jid> muc_jids = new Gee.ArrayList<Jid>();
-            Gee.List<Jid>? occupants = stream_interactor.get_module(MucManager.IDENTITY).get_occupants(conversation.counterpart, conversation.account);
+            Gee.List<Jid>? occupants = stream_interactor.get_module(MucManager.IDENTITY).get_members(conversation.counterpart, conversation.account);
             if (occupants != null) muc_jids.add_all(occupants);
             Gee.List<Jid>? offline_members = stream_interactor.get_module(MucManager.IDENTITY).get_offline_members(conversation.counterpart, conversation.account);
             if (offline_members != null) muc_jids.add_all(offline_members);

--- a/plugins/openpgp/src/manager.vala
+++ b/plugins/openpgp/src/manager.vala
@@ -36,7 +36,7 @@ public class Manager : StreamInteractionModule, Object {
         keys.add(db.get_account_key(conversation.account));
         if (conversation.type_ == Conversation.Type.GROUPCHAT) {
             Gee.List<Jid> muc_jids = new Gee.ArrayList<Jid>();
-            Gee.List<Jid>? occupants = stream_interactor.get_module(MucManager.IDENTITY).get_occupants(conversation.counterpart, conversation.account);
+            Gee.List<Jid>? occupants = stream_interactor.get_module(MucManager.IDENTITY).get_members(conversation.counterpart, conversation.account);
             if (occupants != null) muc_jids.add_all(occupants);
             Gee.List<Jid>? offline_members = stream_interactor.get_module(MucManager.IDENTITY).get_offline_members(conversation.counterpart, conversation.account);
             if (occupants != null) muc_jids.add_all(offline_members);


### PR DESCRIPTION
See #30 

This PR updates `MembersEntry` on the conversation title bar to display all members of the chat and their status (currently `(offline)` label is displayed for offline members).

Current Limitations and Issues:
- Adding or kicking someone with the members tab open will not update members list immediately (reopen the tab for updates)
- Sometimes the members tab cannot be closed (not sure what is the reason, need to investigate).
