### PR TITLE
Add Mac Notification Plugin

### DIFF
--- a/plugins/mac-notification/CMakeLists.txt
+++ b/plugins/mac-notification/CMakeLists.txt
@@ -1,0 +1,28 @@
+find_packages(MAC_NOTIFICATION_PACKAGES REQUIRED
+    Gee
+    GLib
+    GModule
+    GObject
+    GDKPixbuf2
+)
+
+vala_precompile(MAC_NOTIFICATION_VALA_C
+SOURCES
+    src/plugin.vala
+    src/mac_notification_provider.vala
+    src/register_plugin.vala
+CUSTOM_VAPIS
+    ${CMAKE_BINARY_DIR}/exports/xmpp-vala.vapi
+    ${CMAKE_BINARY_DIR}/exports/dino.vapi
+    ${CMAKE_BINARY_DIR}/exports/qlite.vapi
+PACKAGES
+    ${MAC_NOTIFICATION_PACKAGES}
+)
+
+add_definitions(${VALA_CFLAGS})
+add_library(mac-notification SHARED ${MAC_NOTIFICATION_VALA_C})
+target_link_libraries(mac-notification libdino ${MAC_NOTIFICATION_PACKAGES})
+set_target_properties(mac-notification PROPERTIES PREFIX "")
+set_target_properties(mac-notification PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins/)
+
+install(TARGETS mac-notification ${PLUGIN_INSTALL})

--- a/plugins/mac-notification/src/mac_notification_provider.vala
+++ b/plugins/mac-notification/src/mac_notification_provider.vala
@@ -1,0 +1,112 @@
+using Dino;
+using Dino.Entities;
+using Xmpp;
+
+namespace Dino.Plugins.MacNotification {
+
+public class MacNotificationProvider : NotificationProvider, Object {
+    private StreamInteractor stream_interactor;
+    private Dino.Application app;
+
+    public MacNotificationProvider(Dino.Application app) {
+        this.stream_interactor = app.stream_interactor;
+        this.app = app;
+    }
+
+    private void send_notification(string? message) {
+        if (message == null) {
+            return;
+        }
+
+        try {
+            // FIXME: unsafe
+            string[] spawn_args = {"terminal-notifier", "-title", "Dino", "-message", message, "-sound", "default"};
+            string[] spawn_env = Environ.get ();
+            Pid child_pid;
+    
+            Process.spawn_async ("/",
+                spawn_args,
+                spawn_env,
+                SpawnFlags.SEARCH_PATH | SpawnFlags.DO_NOT_REAP_CHILD,
+                null,
+                out child_pid);
+    
+            ChildWatch.add (child_pid, (pid, status) => {
+                // Triggered when the child indicated by child_pid exits
+                Process.close_pid (pid);
+            });
+    
+        } catch (SpawnError e) {
+            print ("Error: %s\n", e.message);
+        }
+    }
+
+    public double get_priority() {
+        return 2.0;
+    }
+
+    public async void notify_message(Message message, Conversation conversation,
+        string conversation_display_name, string? participant_display_name) {
+        // FIXME: unsafe
+        // send_notification(message.body);
+        send_notification("New message");
+    }
+
+    public async void notify_file(FileTransfer file_transfer, Conversation conversation, bool is_image, string conversation_display_name, string? participant_display_name) {
+        warning("TODO: notify file");
+    }
+
+    public async void notify_call(Call call, Conversation conversation, bool video, bool multiparty, string conversation_display_name) {
+        // FIXME: unsafe
+        //  send_notification("Call from " + conversation_display_name);
+        send_notification("New call");
+    }
+
+    public async void retract_call_notification(Call call, Conversation conversation) {
+        warning("TODO: retract call notification");
+    }
+
+    public async void notify_dialing() {
+        warning("TODO: notify dialing");
+    }
+
+    public async void retract_dialing() {
+        warning("TODO: retract dialing");
+    }
+
+    public async void notify_subscription_request(Conversation conversation) {
+        // FIXME: unsafe
+        // send_notification("New contact request from " + conversation.counterpart.to_string());
+        send_notification("New contact request");
+    }
+
+    public async void notify_connection_error(Account account, ConnectionManager.ConnectionError error) {
+        warning("TODO: notify connection error");
+    }
+
+    public async void notify_muc_invite(Account account, Jid room_jid, Jid from_jid, string inviter_display_name) {
+        string display_room = room_jid.bare_jid.to_string();
+
+        // FIXME: unsafe
+        // string body = inviter_display_name + " invited you to " + display_room;
+        send_notification("New invite");
+
+        Conversation group_conversation = stream_interactor.get_module(ConversationManager.IDENTITY).create_conversation(
+            room_jid, account, Conversation.Type.GROUPCHAT);
+        GLib.Application.get_default().activate_action("open-muc-join", new Variant.int32(group_conversation.id));
+    }
+
+    public async void notify_voice_request(Conversation conversation, Jid from_jid) {
+        warning("TODO: notify voice request");
+    }
+
+    public async void retract_content_item_notifications() {
+        warning("TODO: retract content item notifications");
+    }
+
+    public async void retract_conversation_notifications(Conversation conversation) {
+        warning("TODO: retract conversation notifications");
+    }
+}
+
+}

--- a/plugins/mac-notification/src/plugin.vala
+++ b/plugins/mac-notification/src/plugin.vala
@@ -1,0 +1,18 @@
+namespace Dino.Plugins.MacNotification {
+
+public class Plugin : RootInterface, Object {
+
+    public Dino.Application app;
+
+    public void registered(Dino.Application app) {
+        this.app = app;
+
+        app.stream_interactor.get_module(NotificationEvents.IDENTITY)
+            .register_notification_provider(new MacNotificationProvider(app));
+        info("Registered Mac Notification Provider plugin");
+    }
+
+    public void shutdown() { }
+}
+
+}

--- a/plugins/mac-notification/src/register_plugin.vala
+++ b/plugins/mac-notification/src/register_plugin.vala
@@ -1,0 +1,3 @@
+public Type register_plugin(Module module) {
+    return typeof (Dino.Plugins.MacNotification.Plugin);
+}


### PR DESCRIPTION
This PR adds an initial implementation of plugin that allows to display notifications on MacOS. It has a dependency on `terminal-notifier`: https://github.com/julienXX/terminal-notifier

Install `terminal-notifier` with Brew:

```
brew install terminal-notifier
```

On my system I also had to allow notifications from `terminal-notifier` in System Settings.

Build Dino with the `mac-notification` plugin enabled to receive notifications:

```
./configure --enable-plugin=mac-notification
```

Currently the following notifications are displayed:

- Message Notification
- Call Notification
- New Contact Notification
- New MUC Invite Notification