### PR TITLE
Add explicit audio converters to voice processor and echo probe

### DIFF
--- a/plugins/rtp/src/device.vala
+++ b/plugins/rtp/src/device.vala
@@ -433,6 +433,30 @@ public class Dino.Plugins.Rtp.Device : MediaDevice, Object {
         return target;
     }
 
+#if WITH_VOICE_PROCESSOR
+    private Gst.Element create_voice_processor() {
+        Gst.Bin bin = new Gst.Bin("voiceprocessorbin");
+        Gst.Element converter = Gst.ElementFactory.make("audioconvert", @"dsp_convert_$id");
+        Gst.Element resampler = Gst.ElementFactory.make("audioresample", @"dsp_resmaple_$id");
+
+        Gst.Element voiceproc = new VoiceProcessor(plugin.echoprobe as EchoProbe, element as Gst.Audio.StreamVolume);
+        voiceproc.name = @"dsp_$id";
+
+        bin.add_many(converter, resampler, voiceproc);
+        converter.link(resampler);
+        resampler.link(voiceproc);
+
+        Gst.Pad sink_pad = bin.find_unlinked_pad(Gst.PadDirection.SINK);
+        Gst.Pad src_pad = bin.find_unlinked_pad(Gst.PadDirection.SRC);
+        Gst.Pad ghost_source = new Gst.GhostPad("source", src_pad);
+        Gst.Pad ghost_sink = new Gst.GhostPad("sink", sink_pad);
+        bin.add_pad(ghost_source);
+        bin.add_pad(ghost_sink);
+
+        return (Gst.Element)bin;
+    }
+#endif
+
     private void create() {
         debug("Creating device %s", id);
         plugin.pause();
@@ -451,8 +475,7 @@ public class Dino.Plugins.Rtp.Device : MediaDevice, Object {
             element.link(filter);
 #if WITH_VOICE_PROCESSOR
             if (media == "audio" && plugin.echoprobe != null) {
-                dsp = new VoiceProcessor(plugin.echoprobe as EchoProbe, element as Gst.Audio.StreamVolume);
-                dsp.name = @"dsp_$id";
+                dsp = create_voice_processor();
                 pipe.add(dsp);
                 filter.link(dsp);
             }


### PR DESCRIPTION
This PR adds sample rate and audio format conversion for **VoiceProcessor** and **EchoProbe**. This is necessary because the microphone or speakers may not have a 48kHz sampling rate. For example, on Bluetooth headphones on a Mac the sampling frequency is no longer 16 kHz, on Windows in wasapi it is 44.1 kHz. This will be useful to avoid any problems with unknown microphones and headphones.