### PR TITLE
Fix Dino does not refresh expired TURN\STUN server credentials

### DIFF
--- a/plugins/ice/src/plugin.vala
+++ b/plugins/ice/src/plugin.vala
@@ -54,6 +54,21 @@ public class Dino.Plugins.Ice.Plugin : RootInterface, Object {
             ice_udp_module.stun_ip = ip.to_string();
             ice_udp_module.stun_port = 7886;
         }
+
+        if (ice_udp_module.turn_service != null) {
+            int64? expires = ice_udp_module.turn_service.expires;
+            if (expires != null) {
+                uint delay = (uint) (expires - new DateTime.now_utc().to_unix()) / 2;
+
+                debug("Next server external service discovery in %us (because of TURN credentials' expiring time)", delay);
+
+                Timeout.add_seconds(delay, () => {
+                    if (app.stream_interactor.connection_manager.get_state(account) != ConnectionManager.ConnectionState.CONNECTED) return false;
+                    on_stream_negotiated.begin(account, stream);
+                    return false;
+                });
+            }
+        }
     }
 
     public void shutdown() {

--- a/xmpp-vala/src/core/xmpp_stream.vala
+++ b/xmpp-vala/src/core/xmpp_stream.vala
@@ -191,4 +191,12 @@ public abstract class Xmpp.XmppStream : Object {
             }
         }
     }
+
+    public static bool equals_func(XmppStream str1, XmppStream str2) {
+        return str1.remote_name.to_string() == str2.remote_name.to_string();
+    }
+
+    public static uint hash_func(XmppStream str) {
+        return str.remote_name.to_string().hash();
+    }
 }

--- a/xmpp-vala/src/module/xep/0215_external_service_discovery.vala
+++ b/xmpp-vala/src/module/xep/0215_external_service_discovery.vala
@@ -26,7 +26,7 @@ namespace Xmpp.Xep.ExternalServiceDiscovery {
             service.username = service_node.get_attribute("username", NS_URI);
             service.password = service_node.get_attribute("password", NS_URI);
             string? expires_str = service_node.get_attribute("expires", NS_URI);
-            if (expires_str != null) service.expires = DateTimeProfiles.parse_string(expires_str).to_unix();
+            if (expires_str != null) service.expires = DateTimeProfiles.parse_string(expires_str);
 
             service.transport = service_node.get_attribute("transport", NS_URI);
             service.name = service_node.get_attribute("name", NS_URI);
@@ -44,7 +44,7 @@ namespace Xmpp.Xep.ExternalServiceDiscovery {
 
         public string username { get; set; }
         public string password { get; set; }
-        public int64? expires { get; set; }
+        public DateTime? expires { get; set; }
 
         public string transport { get; set; }
         public string name { get; set; }

--- a/xmpp-vala/src/module/xep/0215_external_service_discovery.vala
+++ b/xmpp-vala/src/module/xep/0215_external_service_discovery.vala
@@ -25,6 +25,9 @@ namespace Xmpp.Xep.ExternalServiceDiscovery {
 
             service.username = service_node.get_attribute("username", NS_URI);
             service.password = service_node.get_attribute("password", NS_URI);
+            string? expires_str = service_node.get_attribute("expires", NS_URI);
+            if (expires_str != null) service.expires = DateTimeProfiles.parse_string(expires_str).to_unix();
+
             service.transport = service_node.get_attribute("transport", NS_URI);
             service.name = service_node.get_attribute("name", NS_URI);
             string? restricted_str = service_node.get_attribute("restricted", NS_URI);
@@ -41,6 +44,7 @@ namespace Xmpp.Xep.ExternalServiceDiscovery {
 
         public string username { get; set; }
         public string password { get; set; }
+        public int64? expires { get; set; }
 
         public string transport { get; set; }
         public string name { get; set; }


### PR DESCRIPTION
Add a field in Xmpp.Xep.ExternalServiceDiscovery to keep track of the expires TURN service value and use it (divided by 2) to restart periodically the external services discovery.

Without this patch, calls (actually ICE) fail to initiate after 24h of Dino uptime because of the expiry of the TURN credentials.

This happened on my setup using prosody (using the default credentials' TTL of 86400) and coturn.