### PR TITLE
Add `array_length` attribute for null-terminated Vala arrays

### DIFF
--- a/plugins/openpgp/vapi/gpgme.vapi
+++ b/plugins/openpgp/vapi/gpgme.vapi
@@ -55,9 +55,9 @@ namespace GPG {
         public string issuer_name;
         public string chain_id;
         public Validity owner_trust;
-        [CCode(array_null_terminated = true)]
+        [CCode(array_length = false, array_null_terminated = true)]
         public SubKey[] subkeys;
-        [CCode(array_null_terminated = true)]
+        [CCode(array_length = false, array_null_terminated = true)]
         public UserID[] uids;
         public KeylistMode keylist_mode;
         public string fpr { get { return subkeys[0].fpr; } }


### PR DESCRIPTION
According to the changelog [Vala 0.56.17](https://gitlab.gnome.org/GNOME/vala/raw/0.56/NEWS), null-terminated arrays are treated as such if `array_length = false`.