### PR TITLE
OPENPGP PLUGIN: Show key as expired or revoked in account manager window

### DIFF
--- a/plugins/openpgp/po/de.po
+++ b/plugins/openpgp/po/de.po
@@ -1,9 +1,10 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: dino-openpgp-0.0\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 21:31+0100\n"
-"PO-Revision-Date: 2020-04-16 20:11+0000\n"
+"POT-Creation-Date: 2024-06-09 22:16+0200\n"
+"PO-Revision-Date: 2024-06-09 22:39+0200\n"
+"Last-Translator: eerielili \n"
 "Language-Team: German <https://hosted.weblate.org/projects/dino/plugin-"
 "openpgp/de/>\n"
 "Language: de\n"
@@ -11,11 +12,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.0.1-dev\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #: plugins/openpgp/src/account_settings_entry.vala:68
 #: plugins/openpgp/src/account_settings_entry.vala:72
-#: plugins/openpgp/src/account_settings_entry.vala:101
+#: plugins/openpgp/src/account_settings_entry.vala:113
 msgid "Key publishing disabled"
 msgstr "Schlüsselveröffentlichung deaktiviert"
 
@@ -24,18 +25,40 @@ msgid "Error in GnuPG"
 msgstr "Fehler in GnuPG"
 
 #: plugins/openpgp/src/account_settings_entry.vala:72
-msgid "No keys available. Generate one!"
-msgstr "Keine Schlüssel vorhanden. Erzeuge einen!"
+msgid ""
+"No keys available. Generate one or check if your keys aren't expired or "
+"revoked!"
+msgstr ""
+"Keine Schlüssel vorhanden. Erstellen Sie einen oder prüfen Sie,"
+"ob Ihre Schlüssel nicht abgelaufen sind oder widerrufen!"
 
-#: plugins/openpgp/src/account_settings_entry.vala:101
+
+#: plugins/openpgp/src/account_settings_entry.vala:95
+msgid "expired!"
+msgstr "abgelaufen"
+
+#: plugins/openpgp/src/account_settings_entry.vala:95
+msgid "revoked!"
+msgstr "widerrufen!"
+
+#: plugins/openpgp/src/account_settings_entry.vala:96
+msgid "Attention required!"
+msgstr "Achtung!"
+
+#: plugins/openpgp/src/account_settings_entry.vala:96
+#, c-format
+msgid "Your key %s is %s"
+msgstr "Ihr Schlüssel %s is %s"
+
+#: plugins/openpgp/src/account_settings_entry.vala:113
 msgid "Select key"
 msgstr "Wähle einen Schlüssel"
 
-#: plugins/openpgp/src/account_settings_entry.vala:114
+#: plugins/openpgp/src/account_settings_entry.vala:126
 msgid "Loading…"
 msgstr "Lade…"
 
-#: plugins/openpgp/src/account_settings_entry.vala:114
+#: plugins/openpgp/src/account_settings_entry.vala:126
 msgid "Querying GnuPG"
 msgstr "Frage GnuPG ab"
 
@@ -46,6 +69,3 @@ msgstr "Schlüssel nicht im Schlüsselbund"
 #: plugins/openpgp/src/contact_details_provider.vala:30
 msgid "Encryption"
 msgstr "Verschlüsselung"
-
-#~ msgid "OpenPGP"
-#~ msgstr "OpenPGP"

--- a/plugins/openpgp/po/dino-openpgp.pot
+++ b/plugins/openpgp/po/dino-openpgp.pot
@@ -1,52 +1,68 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 21:31+0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Project-Id-Version: PACKAGE VERSION+\n"
+"POT-Creation-Date: 2024-06-09 22:16+0200\n"
+"PO-Revision-Date: 2024-06-09 22:18+0200\n"
+"Last-Translator: \n"
+"Language-Team: Dino+\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+"X-Poedit-Basepath: ../src\n"
+"X-Poedit-KeywordsList: _(\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-SearchPath-0: .\n"
 
-#: plugins/openpgp/src/account_settings_entry.vala:68
-#: plugins/openpgp/src/account_settings_entry.vala:72
-#: plugins/openpgp/src/account_settings_entry.vala:101
+#: account_settings_entry.vala:68 account_settings_entry.vala:72
+#: account_settings_entry.vala:113
 msgid "Key publishing disabled"
 msgstr ""
 
-#: plugins/openpgp/src/account_settings_entry.vala:68
+#: account_settings_entry.vala:68
 msgid "Error in GnuPG"
 msgstr ""
 
-#: plugins/openpgp/src/account_settings_entry.vala:72
-msgid "No keys available. Generate one!"
+#: account_settings_entry.vala:72
+msgid ""
+"No keys available. Generate one or check if your keys aren't expired or "
+"revoked!"
 msgstr ""
 
-#: plugins/openpgp/src/account_settings_entry.vala:101
+#: account_settings_entry.vala:95
+msgid "expired!"
+msgstr ""
+
+#: account_settings_entry.vala:95
+msgid "revoked!"
+msgstr ""
+
+#: account_settings_entry.vala:96
+msgid "Attention required!"
+msgstr ""
+
+#: account_settings_entry.vala:96
+#, c-format
+msgid "Your key %s is %s"
+msgstr ""
+
+#: account_settings_entry.vala:113
 msgid "Select key"
 msgstr ""
 
-#: plugins/openpgp/src/account_settings_entry.vala:114
+#: account_settings_entry.vala:126
 msgid "Loading…"
 msgstr ""
 
-#: plugins/openpgp/src/account_settings_entry.vala:114
+#: account_settings_entry.vala:126
 msgid "Querying GnuPG"
 msgstr ""
 
-#: plugins/openpgp/src/contact_details_provider.vala:28
+#: contact_details_provider.vala:28
 msgid "Key not in keychain"
 msgstr ""
 
-#: plugins/openpgp/src/contact_details_provider.vala:30
+#: contact_details_provider.vala:30
 msgid "Encryption"
 msgstr ""

--- a/plugins/openpgp/po/fr.po
+++ b/plugins/openpgp/po/fr.po
@@ -7,8 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 21:31+0100\n"
-"PO-Revision-Date: 2020-11-12 17:21+0000\n"
+"POT-Creation-Date: 2024-06-09 22:16+0200\n"
+"PO-Revision-Date: 2024-06-09 22:22+0200\n"
+"Last-Translator: \n"
 "Language-Team: French <https://hosted.weblate.org/projects/dino/plugin-"
 "openpgp/fr/>\n"
 "Language: fr\n"
@@ -16,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.4-dev\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #: plugins/openpgp/src/account_settings_entry.vala:68
 #: plugins/openpgp/src/account_settings_entry.vala:72
-#: plugins/openpgp/src/account_settings_entry.vala:101
+#: plugins/openpgp/src/account_settings_entry.vala:113
 msgid "Key publishing disabled"
 msgstr "La publication des clés est désactivée"
 
@@ -29,18 +30,39 @@ msgid "Error in GnuPG"
 msgstr "Erreur dans GnuPG"
 
 #: plugins/openpgp/src/account_settings_entry.vala:72
-msgid "No keys available. Generate one!"
-msgstr "Aucune clé n’est disponible. Générez-en une !"
+msgid ""
+"No keys available. Generate one or check if your keys aren't expired or "
+"revoked!"
+msgstr ""
+"Pas de clés disponibles. Générez-en une nouvelle ou vérifier si vos "
+"clés ne seraient pas expirées ou révoquées!"
 
-#: plugins/openpgp/src/account_settings_entry.vala:101
+#: plugins/openpgp/src/account_settings_entry.vala:95
+msgid "expired!"
+msgstr "expirée!"
+
+#: plugins/openpgp/src/account_settings_entry.vala:95
+msgid "revoked!"
+msgstr "révoquée!"
+
+#: plugins/openpgp/src/account_settings_entry.vala:96
+msgid "Attention required!"
+msgstr "Attention requise!"
+
+#: plugins/openpgp/src/account_settings_entry.vala:96
+#, c-format
+msgid "Your key %s is %s"
+msgstr "Votre clé %s est %s"
+
+#: plugins/openpgp/src/account_settings_entry.vala:113
 msgid "Select key"
 msgstr "Choix d’une clé"
 
-#: plugins/openpgp/src/account_settings_entry.vala:114
+#: plugins/openpgp/src/account_settings_entry.vala:126
 msgid "Loading…"
 msgstr "Chargement…"
 
-#: plugins/openpgp/src/account_settings_entry.vala:114
+#: plugins/openpgp/src/account_settings_entry.vala:126
 msgid "Querying GnuPG"
 msgstr "Interrogation de GnuPG"
 

--- a/plugins/openpgp/po/ru.po
+++ b/plugins/openpgp/po/ru.po
@@ -7,8 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 21:31+0100\n"
-"PO-Revision-Date: 2020-06-02 11:41+0000\n"
+"POT-Creation-Date: 2024-06-09 22:16+0200\n"
+"PO-Revision-Date: 2024-06-09 22:39+0200\n"
+"Last-Translator: eerielili\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/dino/plugin-"
 "openpgp/ru/>\n"
 "Language: ru\n"
@@ -17,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"X-Generator: Weblate 4.1-dev\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #: plugins/openpgp/src/account_settings_entry.vala:68
 #: plugins/openpgp/src/account_settings_entry.vala:72
-#: plugins/openpgp/src/account_settings_entry.vala:101
+#: plugins/openpgp/src/account_settings_entry.vala:113
 msgid "Key publishing disabled"
 msgstr "Публикация ключа отключена"
 
@@ -30,18 +31,37 @@ msgid "Error in GnuPG"
 msgstr "Ошибка в GnuPG"
 
 #: plugins/openpgp/src/account_settings_entry.vala:72
-msgid "No keys available. Generate one!"
+msgid ""
+"No keys available. Generate one or check if your keys aren't expired or "
+"revoked!"
 msgstr "Нет доступных ключей. Создайте как минимум один, либо проверьте что уже существующие (ранее созданные) ключи не были отозваны или срок их действия не закончился!"
 
-#: plugins/openpgp/src/account_settings_entry.vala:101
+#: plugins/openpgp/src/account_settings_entry.vala:95
+msgid "expired!"
+msgstr "истёк!"
+
+#: plugins/openpgp/src/account_settings_entry.vala:95
+msgid "revoked!"
+msgstr "отозван!"
+
+#: plugins/openpgp/src/account_settings_entry.vala:96
+msgid "Attention required!"
+msgstr "внимание!"
+
+#: plugins/openpgp/src/account_settings_entry.vala:96
+#, c-format
+msgid "Your key %s is %s"
+msgstr "аш ключ %s %s"
+
+#: plugins/openpgp/src/account_settings_entry.vala:113
 msgid "Select key"
 msgstr "Выбрать ключ"
 
-#: plugins/openpgp/src/account_settings_entry.vala:114
+#: plugins/openpgp/src/account_settings_entry.vala:126
 msgid "Loading…"
 msgstr "Загрузка…"
 
-#: plugins/openpgp/src/account_settings_entry.vala:114
+#: plugins/openpgp/src/account_settings_entry.vala:126
 msgid "Querying GnuPG"
 msgstr "Запрос GnuPG"
 

--- a/plugins/openpgp/src/account_settings_entry.vala
+++ b/plugins/openpgp/src/account_settings_entry.vala
@@ -69,7 +69,7 @@ public class AccountSettingsEntry : Plugins.AccountSettingsEntry {
             return;
         }
         if (keys.size == 0) {
-            label.set_markup(build_markup_string(_("Key publishing disabled"), _("No keys available. Generate one!")));
+            label.set_markup(build_markup_string(_("Key publishing disabled"), _("No keys available. Generate one or check if your keys aren't expired or revoked!")));
             return;
         }
 
@@ -88,6 +88,18 @@ public class AccountSettingsEntry : Plugins.AccountSettingsEntry {
         set_label_active(selected);
 
         combobox.changed.connect(key_changed);
+        if (account_key != null) {
+            try {
+                GPG.Key key_check = GPGHelper.get_public_key(account_key);
+                if(key_check.expired || key_check.revoked) {
+                    string status_str = key_check.expired ? _("expired!") : _("revoked!");
+                    label.set_markup(build_markup_string(_("Attention required!"), _("Your key %s is %s").printf("<span color='red'><b>"+ key_check.fpr +"</b></span>", status_str) ) );
+                }
+            }
+            catch {
+                debug("Coudn't check GPG key status.");
+            }
+        }
     }
 
     private void populate_list_store() {


### PR DESCRIPTION
A small update concerning the openpgp plugin: with this, the key can be shown either as expired or revoked in the account manager windows concerning an account.
![image](https://github.com/mxlgv/dino/assets/81772782/dfe52142-061f-462e-9391-a8bace9306ff)
