### PR TITLE
Fix build after MinGW update

### DIFF
--- a/build-win64.sh
+++ b/build-win64.sh
@@ -21,13 +21,13 @@ fatal()
 
 download_yolort()
 {
-    file_name=cppwinrt-2.0.210122.3+windows-10.0.19041+yolort-835cd4e.zip
+    file_name=yolort.zip
     yolort_dir="$PROJ_DIR/plugins/windows-notification/yolort"
 
     rm -rf "$yolort_dir"
     mkdir "$yolort_dir"
-    curl -L -o "$file_name" "https://github.com/LAGonauta/YoloRT/releases/download/v1.0.0/$file_name"
-    echo "675a6d943c97b4acdbfaa473f68d3241d1798b31a67b5529c8d29fc0176a1707 $file_name" | sha256sum --check --status
+    curl -L -o "$file_name" "https://github.com/mxlgv/YoloRT/releases/download/dev1/$file_name"
+    echo "c2727e390da7e842f66e0a4cf0a9f5d9dfb665115bb554152d98f108d322bbc1 $file_name" | sha256sum --check --status
     unzip -o "$file_name" -d "$yolort_dir"
     rm -f "$file_name"
 }

--- a/libdino/src/service/util.vala
+++ b/libdino/src/service/util.vala
@@ -6,7 +6,7 @@ namespace Dino {
 public class Util {
     #if _WIN32
     [CCode (cname = "ShellExecuteA", cheader_filename = "windows.h")]
-    private static extern int ShellExecuteA(int* hwnd, string operation, string file, string parameters, string directory, int showCmd);
+    private static extern int* ShellExecuteA(int* hwnd, string operation, string file, string parameters, string directory, int showCmd);
 
     [CCode (cname = "CoInitialize", cheader_filename = "windows.h")]
     private static extern int CoInitialize(void* reserved);
@@ -14,7 +14,7 @@ public class Util {
     [CCode (cname = "CoUninitialize", cheader_filename = "windows.h")]
     private static extern void CoUninitialize();
 
-    private static int ShellExecute(string operation, string file) {
+    private static int* ShellExecute(string operation, string file) {
         CoInitialize(null);
         var result = ShellExecuteA(null, operation, file, null, null, 1);
         CoUninitialize();


### PR DESCRIPTION
- Fixed  `HINSTANCE` cast error for `ShellExecuteA`;
- Fixed YoloRT headers for compilation with GCC 14.