### PR TITLE
Bump Flatpak runtime "org.gnome.Platform" version to 46

### DIFF
--- a/im.dino.Dino.json
+++ b/im.dino.Dino.json
@@ -1,7 +1,7 @@
 {
     "id": "im.dino.Dino",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "command": "dino",
     "finish-args": [


### PR DESCRIPTION
This should fix it: https://github.com/mxlgv/dino/issues/74
