### PR TITLE
Show contact status in "Start chat" window

### DIFF
--- a/main/data/add_conversation/list_row.ui
+++ b/main/data/add_conversation/list_row.ui
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
     <requires lib="gtk" version="4.0"/>
-    <object class="GtkGrid" id="outer_grid">
-        <property name="margin-start">3</property>
-        <property name="margin-end">3</property>
-        <property name="margin-top">3</property>
-        <property name="margin-bottom">3</property>
-        <property name="column-spacing">10</property>
+    <object class="GtkBox" id="outer_box">
+        <property name="orientation">horizontal</property>
+        <property name="spacing">8</property>
+        <property name="margin-start">6</property>
+        <property name="margin-end">6</property>
+        <property name="margin-top">6</property>
+        <property name="margin-bottom">6</property>
         <child>
             <object class="DinoUiAvatarPicture" id="picture">
                 <property name="height-request">30</property>
@@ -15,34 +16,33 @@
             </object>
         </child>
         <child>
-            <object class="GtkGrid">
-                <property name="valign">center</property>
+            <object class="GtkBox">
                 <property name="orientation">vertical</property>
+                <property name="valign">center</property>
                 <child>
-                    <object class="GtkLabel" id="name_label">
-                        <property name="max_width_chars">1</property>
-                        <property name="ellipsize">end</property>
-                        <property name="hexpand">1</property>
-                        <property name="xalign">0</property>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                        </layout>
+                    <object class="GtkBox">
+                        <property name="orientation">horizontal</property>
+                        <property name="spacing">6</property>
+                        <child>
+                            <object class="GtkLabel" id="name_label">
+                                <property name="ellipsize">end</property>
+                                <property name="xalign">0</property>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="GtkImage" id="status_dot">
+                                <property name="pixel-size">8</property>
+                            </object>
+                        </child>
                     </object>
                 </child>
                 <child>
                     <object class="GtkLabel" id="via_label">
-                        <property name="max_width_chars">1</property>
                         <property name="ellipsize">end</property>
-                        <property name="hexpand">1</property>
                         <property name="xalign">0</property>
                         <attributes>
                             <attribute name="scale" value="0.8"></attribute>
                         </attributes>
-                        <layout>
-                            <property name="column">0</property>
-                            <property name="row">1</property>
-                        </layout>
                     </object>
                 </child>
             </object>

--- a/main/src/ui/add_conversation/conference_list.vala
+++ b/main/src/ui/add_conversation/conference_list.vala
@@ -103,6 +103,7 @@ internal class ConferenceListRow : ListRow {
         this.account = account;
         this.bookmark = bookmark;
 
+        status_dot.visible = false;
         name_label.label = bookmark.name != null && bookmark.name != "" ? bookmark.name : bookmark.jid.to_string();
         if (stream_interactor.get_accounts().size > 1) {
             via_label.label = "via " + account.bare_jid.to_string();

--- a/main/src/ui/add_conversation/list_row.vala
+++ b/main/src/ui/add_conversation/list_row.vala
@@ -8,26 +8,68 @@ namespace Dino.Ui {
 
 public class ListRow : Widget {
 
-    public Grid outer_grid;
+    public Box outer_box;
     public AvatarPicture picture;
     public Label name_label;
+    public Image status_dot;
     public Label via_label;
 
+    public string? status_str;
     public Jid? jid;
     public Account? account;
 
     construct {
         Builder builder = new Builder.from_resource("/im/dino/Dino/add_conversation/list_row.ui");
-        outer_grid = (Grid) builder.get_object("outer_grid");
+        outer_box = (Box) builder.get_object("outer_box");
         picture = (AvatarPicture) builder.get_object("picture");
         name_label = (Label) builder.get_object("name_label");
+        status_dot = (Image) builder.get_object("status_dot");
         via_label = (Label) builder.get_object("via_label");
 
+
         this.layout_manager = new BinLayout();
-        outer_grid.set_parent(this);
+        outer_box.set_parent(this);
     }
 
     public ListRow() {}
+
+    private void set_status_dot(StreamInteractor stream_interactor, Jid jid, Account account){
+        Gee.List<Jid>? full_jids = stream_interactor.get_module(PresenceManager.IDENTITY).get_full_jids(jid, account);
+        string presences = "";
+        if (full_jids != null){
+            for (int i = 0; i < full_jids.size; i++) {
+                Jid full_jid = full_jids[i];
+                string presence = stream_interactor.get_module(PresenceManager.IDENTITY).get_last_show(full_jid, account);
+                presences += presence + " ";
+            }
+        } else presences = null;
+
+        if (presences == null){
+            status_dot.set_from_icon_name("dino-status-offline");
+            return;
+        }
+        // Do not disturb > Interested in Chatting > Online > Away = Extended Away
+        if(presences.contains(Presence.Stanza.SHOW_DND)) {
+            status_dot.set_from_icon_name("dino-status-dnd");
+            return;
+        }
+
+        if(presences.contains(Presence.Stanza.SHOW_CHAT)){
+            status_dot.set_from_icon_name("dino-status-chat");
+            return;
+        }
+
+        if(presences.contains(Presence.Stanza.SHOW_ONLINE)) {
+            status_dot.set_from_icon_name("dino-status-online");
+            return;
+        }
+
+        if(presences.contains(Presence.Stanza.SHOW_AWAY) || presences.contains(Presence.Stanza.SHOW_XA)) {
+            status_dot.set_from_icon_name("dino-status-away");
+            return;
+        }
+
+    }
 
     public ListRow.from_jid(StreamInteractor stream_interactor, Jid jid, Account account, bool show_account) {
         this.jid = jid;
@@ -46,10 +88,11 @@ public class ListRow : Widget {
         }
         name_label.label = display_name;
         picture.model = new ViewModel.CompatAvatarPictureModel(stream_interactor).set_conversation(conv);
+        set_status_dot(stream_interactor, jid, account);
     }
 
     public override void dispose() {
-        outer_grid.unparent();
+        outer_box.unparent();
     }
 }
 


### PR DESCRIPTION
Should close https://github.com/dino/dino/issues/139 and come in handy to know when someone is online or busy before opening a new chat with them.


Online:
![image](https://github.com/dino/dino/assets/81772782/3a2e8528-071d-4dc6-97a7-1673cdc7fd52)


DND:
![image](https://github.com/dino/dino/assets/81772782/fd7b3aec-437f-4658-851a-c963477c7a7d)

Away and extended away:
![image](https://github.com/dino/dino/assets/81772782/30a75bfb-a08e-4915-8f00-9ada2ca45e80)

Offline:
![image](https://github.com/dino/dino/assets/81772782/61ff8b91-0ad1-4430-9072-ae82b82e704c)

There's also the "open for chats / wanting  to chat" status with this icon:
![image](https://github.com/dino/dino/assets/81772782/c934e631-403c-4f31-9ba1-e826d167fcb9)
But i couldn't test it out. I still included it in the code.
