### PR TITLE
Fix crash when toggling an account very fast (#1505)

### DIFF
--- a/main/src/ui/manage_accounts/dialog.vala
+++ b/main/src/ui/manage_accounts/dialog.vala
@@ -197,6 +197,7 @@ public class Dialog : Gtk.Dialog {
     }
 
     private void populate_grid_data(Account account) {
+        active_switch.sensitive = false;
         active_switch.state_set.disconnect(change_account_state);
 
         picture.model = new ViewModel.CompatAvatarPictureModel(stream_interactor).add_participant(new Conversation(account.bare_jid, account, Conversation.Type.CHAT), account.bare_jid);
@@ -227,11 +228,14 @@ public class Dialog : Gtk.Dialog {
             ConnectionManager.ConnectionState state = stream_interactor.connection_manager.get_state(account);
             switch (state) {
                 case ConnectionManager.ConnectionState.CONNECTING:
+                    active_switch.sensitive = false;
                     state_label.label = _("Connecting…"); break;
                 case ConnectionManager.ConnectionState.CONNECTED:
+                    active_switch.sensitive = true;
                     password_change_btn.sensitive = true;
                     state_label.label = _("Connected"); break;
                 case ConnectionManager.ConnectionState.DISCONNECTED:
+                    active_switch.sensitive = true;
                     password_change_btn.sensitive = false;
                     state_label.label = _("Disconnected"); break;
             }


### PR DESCRIPTION
Mostly fix #1505.
The switch widget in the account managment
dialog is now not accepting input while the account
being enabled is connecting, preventing an user to switch it on and off too fast.
I've tested it and it becomes very very rare to trigger the crash in #1505.