### PR TITLE
Add filename tooltip for images

### DIFF
--- a/main/src/ui/conversation_content_view/file_image_widget.vala
+++ b/main/src/ui/conversation_content_view/file_image_widget.vala
@@ -73,6 +73,9 @@ public class FileImageWidget : Box {
             image_overlay_toolbar.visible = false;
         });
 
+        // Set tooltip to display the file name on hover
+        image.set_tooltip_text(file_name);
+
         this.append(overlay);
     }
 }


### PR DESCRIPTION
Hovering over an image with your cursor will now display a tooltip containing the filename.
This solves the difficulty of seeing what an image's file name is and makes it much more convenient.
![2024-08-06 19_52_08](https://github.com/user-attachments/assets/e99b37fa-58f2-42bf-b82b-3be65e9f8d78)
